### PR TITLE
Allow null default values in validation set

### DIFF
--- a/validator/Validation_Set.php
+++ b/validator/Validation_Set.php
@@ -26,7 +26,7 @@ class Validation_Set implements Validation_Interface
             return;
         }
 
-        if (!isset($param)) {
+        if (!isset($param) && !is_null($param)) {
             throw new Exception('Validation rule \''.__METHOD__.'\', missing parameter.');
         }
 


### PR DESCRIPTION
Null defaults are used by /UI/Login.php for the POST back URL param for instance.

More discussion on https://github.com/ostepu/ostepu-core/issues/328